### PR TITLE
use HTML parse_mode to prevent telegram parsing error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,19 +52,20 @@ exports.register = function(app) {
 		req.end(JSON.stringify({
 			chat_id: params.recipient,
 			text: params.message,
-			parse_mode: 'Markdown',
+			parse_mode: 'HTML',
 			disable_web_page_preview: true
 		}));
 	};
 
 	Transport.prototype._messageTemplate = _(
-		'<%= build.project.name %> build [#<%= build.number %>](<%= baseUrl %>/builds/<%= build.id %>) ' +
-		'initiated by <%= build.initiator.type %> is *<%= build.status %>* ' +
-		'<%= emoji %>\n\n' + 
-		'<% if (changes.length) { %>' + 
+		'<strong><%- build.project.name %></strong> build ' +
+		'<a href="<%- baseUrl %>/builds/<%- build.id %>">[#<%- build.number %>]</a> ' +
+		'initiated by <%- build.initiator.type %> is <strong><%- build.status %></strong> ' +
+		'<%- emoji %>\n\n' +
+		'<% if (changes.length) { %>' +
 			'scm changes:\n' +
 			'<% _(changes).chain().first(20).each(function(change, index) { %>' +
-				'<%= change.author %>: `<%= change.comment %>`\n' +
+				'\u2219 <%- change.author %>: <code><%- change.comment %></code>\n' +
 			'<% }); %>' +
 			'<% if (changes.length > 20) { %>' +
 				'...\n' +
@@ -74,7 +75,7 @@ exports.register = function(app) {
 		'<% } %>' +
 		'\n' +
 		'<% if (build.status === \'error\') { %>' +
-			'failed at *<%= build.currentStep%>*' +
+			'failed at <strong><%- build.currentStep %></strong>' +
 		'<% } %>'
 	).template();
 


### PR DESCRIPTION
NCI could not send a message and logs an error: `"Bad Request: can't parse entities in message text: Can't find end of the entity starting at byte 12"` when project name contains underscores: `foo_baz_bar_boo`.

This PR changes `parse_mode` to `HTML` and rewrites message template using simple html tags supported by telegram api https://core.telegram.org/bots/api#formatting-options.
Also it changes `<%=` interpolation to `<%-` that escape HTML special chars.

I tried to escape markdown special chars with back-slash but it didn't work =(